### PR TITLE
Update lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rxjs": "^6.0.0"
   },
   "dependencies": {
-    "lodash": "4.17.11"
+    "lodash": "4.17.12"
   },
   "devDependencies": {
     "@angular/animations": "^6.0.0",


### PR DESCRIPTION
Lodash version 4.17.11 generates a high severity vulnerability (detected by npm). This vulnerability has been fixed in the next version (4.17.12).

<img width="192" alt="severity-canvas" src="https://user-images.githubusercontent.com/15010744/70228193-3b6e5680-1754-11ea-9ecd-9c7ade58171f.PNG">
