### PR TITLE
Fix for CORS images on canvas

### DIFF
--- a/projects/ng2-canvas-whiteboard/src/lib/canvas-whiteboard.component.ts
+++ b/projects/ng2-canvas-whiteboard/src/lib/canvas-whiteboard.component.ts
@@ -409,6 +409,7 @@ export class CanvasWhiteboardComponent implements OnInit, AfterViewInit, OnChang
     }
 
     this._imageElement = new Image();
+    this._imageElement.crossOrigin = 'Anonymous';
     this._imageElement.addEventListener('load', () => {
       this._canDraw = true;
       callbackFn && callbackFn();


### PR DESCRIPTION
Loading an image as background from another domain is possible, but when saving the image an error is thrown (Firefox).

`ERROR DOMException: The operation is insecure.`

This happens when calling the canvasToDataUrl on a canvas. 

More information: [https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image)
