### PR TITLE
Fix canvas resize triggering redraw of undone shapes

### DIFF
--- a/projects/ng2-canvas-whiteboard/package-lock.json
+++ b/projects/ng2-canvas-whiteboard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-canvas-whiteboard",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
- Set visibility for re-drawn shapes based on previous shapes
- Don't clear _undoStack if clearing for redraw
- Add methods to get current status of allowing undo and redo

May be a better way to do this. Open to feedback